### PR TITLE
Retry track on load error and fix playlist loading

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -26,5 +26,10 @@
       <option name="name" value="maven" />
       <option name="url" value="https://m2.dv8tion.net/releases" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven3" />
+      <option name="name" value="maven3" />
+      <option name="url" value="https://maven.lavalink.dev/releases" />
+    </remote-repository>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ repositories {
     mavenCentral()
     maven {url('https://m2.dv8tion.net/releases')}
     maven {url('https://jitpack.io')}
+    maven {url("https://maven.lavalink.dev/releases")}
 }
 
 dependencies {
@@ -18,8 +19,11 @@ dependencies {
     implementation("net.dv8tion:JDA:5.0.0-beta.6")
 
     // Lavaplayer
-    implementation("com.github.kamilake:lavaplayer:main-SNAPSHOT") // temp fix for Video returned is not what was requested error.
+    implementation("dev.arbjerg:lavaplayer:2.1.2")
     implementation('com.github.Topis-Lavalink-Plugins:Topis-Source-Managers:2.0.7')
+
+    // New Youtube source
+    implementation("dev.lavalink.youtube:v2:1.1.0")
 
     // VOSK
     implementation('net.java.dev.jna:jna:5.12.1')

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.reign'
-version '1.2.0'
+version '1.2.5-errortest'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,6 @@ dependencies {
     implementation("net.dv8tion:JDA:5.0.0-beta.6")
 
     // Lavaplayer
-    //implementation('com.github.walkyst:lavaplayer-fork:1.4.2')
-    //implementation("io.github.lavalink-devs:lavaplayer:2.1.1")
     implementation("com.github.kamilake:lavaplayer:main-SNAPSHOT") // temp fix for Video returned is not what was requested error.
     implementation('com.github.Topis-Lavalink-Plugins:Topis-Source-Managers:2.0.7')
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.reign'
-version '1.2.7-errortest'
+version '1.2.7'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.reign'
-version '1.2.5-errortest'
+version '1.2.7-errortest'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/reign/kat/lib/voice/newvoice/GuildPlaylistPool.java
+++ b/src/main/java/com/reign/kat/lib/voice/newvoice/GuildPlaylistPool.java
@@ -3,6 +3,10 @@ package com.reign.kat.lib.voice.newvoice;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers;
+import dev.lavalink.youtube.YoutubeAudioSourceManager;
+import dev.lavalink.youtube.clients.Android;
+import dev.lavalink.youtube.clients.Music;
+import dev.lavalink.youtube.clients.Web;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,6 +27,7 @@ public class GuildPlaylistPool
     {
         // All source managers get initialized here.
         playerManager.registerSourceManager(SpotifyRemoteSource.build(playerManager));
+        playerManager.registerSourceManager(new YoutubeAudioSourceManager(true, new Web(), new Music(), new Android()));
         AudioSourceManagers.registerRemoteSources(playerManager);
     }
 

--- a/src/main/java/com/reign/kat/lib/voice/newvoice/PlaylistPlayer.java
+++ b/src/main/java/com/reign/kat/lib/voice/newvoice/PlaylistPlayer.java
@@ -13,6 +13,8 @@ public class PlaylistPlayer extends AudioEventAdapter
 {
     private static final Logger log = LoggerFactory.getLogger(PlaylistPlayer.class);
 
+    public static final int ERROR_LIMIT = 3;
+
     /** LavaPlayer AudioPlayer instance. This class DOES NOT manage JDAs audio player. */
     public final AudioPlayer lavaPlayer;
 

--- a/src/main/java/com/reign/kat/lib/voice/newvoice/PlaylistQueue.java
+++ b/src/main/java/com/reign/kat/lib/voice/newvoice/PlaylistQueue.java
@@ -36,6 +36,8 @@ public class PlaylistQueue
         queue.add(track);
     }
 
+    public void enqueueFront(RequestedTrack track) { queue.add(0, track);}
+
     public List<RequestedTrack> search(Member m, String q)
     {
         List<RequestedTrack> addedTracks = new ArrayList<>();


### PR DESCRIPTION
Sometimes, when trying to play a track after a long absence of music, the bot will throw a "Something broke whilst playing the track" error which does not appear when playing again. Now we try the track again (by default 3 times) before erroring and skipping the track.

Also updates lavaplayer with the new youtube source which recently released.