### PR TITLE
1.3.5 - Spring Cleaning Update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.reign'
-version '1.3.1-ythotfix'
+version '1.3.5'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/reign/kat/commands/voice/ExportPlaylistCommand.java
+++ b/src/main/java/com/reign/kat/commands/voice/ExportPlaylistCommand.java
@@ -1,0 +1,50 @@
+package com.reign.kat.commands.voice;
+
+import com.reign.kat.lib.command.Command;
+import com.reign.kat.lib.command.CommandParameters;
+import com.reign.kat.lib.command.Context;
+import com.reign.kat.lib.converters.GreedyStringConverter;
+import com.reign.kat.lib.converters.VideoSourceGreedyConverter;
+import com.reign.kat.lib.voice.newvoice.GuildPlaylist;
+import com.reign.kat.lib.voice.newvoice.GuildPlaylistPool;
+import net.dv8tion.jda.api.utils.FileUpload;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+public class ExportPlaylistCommand extends Command {
+    private static final Logger log = LoggerFactory.getLogger(ExportPlaylistCommand.class);
+
+    public ExportPlaylistCommand() {
+        super(new String[]{"export", "e"}, "export", "Exports the current loaded tracks to a file.");
+        addConverter(new GreedyStringConverter(
+                "filename",
+                "Name of a song or URL",
+                DateTimeFormatter.BASIC_ISO_DATE.format(LocalDateTime.now())
+        ));
+        setShowTyping(true);
+    }
+
+    @Override
+    public void execute(Context ctx, CommandParameters args) throws Exception {
+        GuildPlaylist playlist = GuildPlaylistPool.get(ctx.guild.getIdLong());
+        playlist.getResponseHandler().setTextChannelID(ctx.channel().getIdLong());
+
+
+        if (ctx.canProvideInteractionHook())
+            playlist.getResponseHandler().setHook(ctx.hook());
+
+        String filename = args.get("filename") + ".kat";
+        String export = playlist.export();
+        InputStream stream = new ByteArrayInputStream(export.getBytes(StandardCharsets.UTF_8));
+
+        ctx.channel().sendFiles(FileUpload.fromData(stream, filename)).queue();
+        ctx.send(String.format("Exported (%d) tracks to `%s`", playlist.getQueue().size(), filename));
+    }
+}

--- a/src/main/java/com/reign/kat/commands/voice/VoiceCategory.java
+++ b/src/main/java/com/reign/kat/commands/voice/VoiceCategory.java
@@ -58,6 +58,7 @@ public class VoiceCategory extends Category {
         registerCommand(new MoveCommand());
         registerCommand(new RemoveCommand());
         registerCommand(new ClearPlaylistCommand());
+        registerCommand(new ExportPlaylistCommand());
 
         registerCommand(new LeaveCommand());
         registerCommand(new JoinCommand());
@@ -95,6 +96,8 @@ public class VoiceCategory extends Category {
             );
 
             executeCommand(ctx);
+            if (!event.isAcknowledged())
+                event.reply("Queued").setEphemeral(true).queue();
 
         }
 

--- a/src/main/java/com/reign/kat/lib/voice/newvoice/GuildPlaylist.java
+++ b/src/main/java/com/reign/kat/lib/voice/newvoice/GuildPlaylist.java
@@ -106,7 +106,23 @@ public class GuildPlaylist extends AudioEventAdapter
     public void seek(long position) { player.seek(position); }
     public MessageChannel getLastTextChannel() { return Bot.jda.getTextChannelById(responseHandler.getTextChannelID()); }
 
+    /***
+     * Export the current loaded playlist
+     * @return String, list of loaded tracks
+     */
+    public String export() {
+        StringBuilder s = new StringBuilder();
 
+        if (nowPlaying() != null) {
+            s.append(nowPlaying().url).append("\n");
+        }
+
+        queue.getQueue().forEach(track -> {
+            s.append(track.url).append("\n");
+        });
+
+        return s.toString();
+    }
 
     public GuildPlaylistResponseHandler getResponseHandler() { return responseHandler; }
 


### PR DESCRIPTION
## Changelog
+ Updated JDA 5.0.0 -> 5.1.1
+ Fixed button interaction showing "interaction failed" when the command was successfully executed
+ Updated YT sources
+ Removed now broken Android YT source

## Export Playlist Command
> [!Note]
> This is simply a list of queued tracks. Although you can export, there is currently no way to import playlists. This will be coming at a later date.

`!export [filename]` will now export the current queued and now playing tracks as an attachment. If you do not provide an optional filename it will be exported as the date in format `yymmdd.kat`.
For now, this export is just the urls of the tracks new line separated. In the future this may change to include more information about the playlist.

## Dockerisation
I am experimenting with Docker and running Kat inside of a docker container. So far, I have been able to get her running without issue. Next update I will add the Dockerfile and maybe rethink how artifacts are built to make building the docker image easier.

Along with Kat, her DB and API are also being dockerised, which will result in 3 images once this is completed:
 + kat-bot
 + kat-db
 + kat-api

Since they all depend on each other, It may be easiest to have the java bot itself start/host the db and API, although I'm not sure if this is possible/a good way to do things...
