### PR TITLE
Datastores for commands

### DIFF
--- a/src/main/java/com/reign/api/kat/models/ApiGuild.java
+++ b/src/main/java/com/reign/api/kat/models/ApiGuild.java
@@ -11,6 +11,8 @@ import org.bson.Document;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -23,7 +25,7 @@ public class ApiGuild extends ApiModel
     public @JsonProperty("members") ArrayList<String> members;
     public @JsonProperty("prefix") String prefix;
     //public @JsonProperty("dashboard_enabled") boolean dashboardEnabled;
-    public @JsonProperty("command") Document commandData;
+    public @JsonProperty("command") Map<String, Object> commandData;
     public @JsonProperty("permission_groups") PermissionGroups permissionGroups;
 
     protected static ApiCache<ApiGuild> cache = new ApiCache<>(ApiGuild.class);
@@ -33,7 +35,7 @@ public class ApiGuild extends ApiModel
         super();
         this.discoveredAt = Instant.now().getEpochSecond();
         this.prefix = Config.PREFIX;
-        this.commandData = new Document();
+        this.commandData = new HashMap<>();
     }
     public ApiGuild(String snowflake)
     {

--- a/src/main/java/com/reign/kat/commands/debug/DatastoreTestCommand.java
+++ b/src/main/java/com/reign/kat/commands/debug/DatastoreTestCommand.java
@@ -1,0 +1,106 @@
+package com.reign.kat.commands.debug;
+
+import com.reign.api.kat.models.ApiGuild;
+import com.reign.kat.Bot;
+import com.reign.kat.lib.command.Command;
+import com.reign.kat.lib.command.CommandParameters;
+import com.reign.kat.lib.command.Context;
+import com.reign.kat.lib.command.category.Category;
+import com.reign.kat.lib.command.data.Datastore;
+import com.reign.kat.lib.command.data.DatastoreField;
+import com.reign.kat.lib.converters.GreedyStringConverter;
+import com.reign.kat.lib.converters.StringConverter;
+import com.reign.kat.lib.embeds.ExceptionEmbed;
+import com.reign.kat.lib.embeds.GenericEmbedBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.stream.Collectors;
+
+
+public class DatastoreTestCommand extends Command {
+    private static final Logger log = LoggerFactory.getLogger(DatastoreTestCommand.class);
+
+    public DatastoreTestCommand() {
+        super(new String[]{"ds"}, "datastore" ,"test datastore functionality.");
+        addConverter(new GreedyStringConverter("command", "Name of the command to check data structure for", ""));
+
+        setDatastore()
+                .addField("test.array", new DatastoreField<>(new ArrayList<>()))
+                .addField("test.check_enable", new DatastoreField<>(false))
+                .addField("test.count", new DatastoreField<>(0));
+    }
+
+    public static Command findCommand(List<Command> commands, String name) {
+        // Iterate over the list of commands
+        for (Command command : commands) {
+            // Check if the current command matches the target name
+            if (command.getClass().getSimpleName().equals(name)) {
+                log.debug("FOUND COMMAND");
+                return command;
+            }
+            // Recursively search through children
+            Command result = findCommand(command.getChildren(), name);
+            if (result != null) {
+                return result;  // Found the command in the children
+            }
+        }
+        return null;  // Not found in this branch
+    }
+
+    @Override
+    public void execute(Context ctx, CommandParameters params) {
+        ApiGuild guild = ApiGuild.get(ctx.guild.getId());
+
+        Command cmd = null;
+
+        for (Category cat : Bot.commandHandler.getCategories())
+        {
+            cmd = findCommand(cat.getCommandsDistinct().stream().toList(), params.get("command"));
+            if (cmd != null) { break; }
+        }
+
+        if (cmd != null) {
+            try {
+                Datastore d = null;
+                for (Field f : cmd.getClass().getSuperclass().getDeclaredFields()) {
+                    if (f.getName().equals("datastore")) {
+                        d = (Datastore) f.get(cmd);
+                    }
+                }
+
+                if (d == null) { throw new NoSuchFieldException(""); }
+
+
+                StringBuilder sb = new StringBuilder();
+
+                for (Iterator<Map.Entry<String, DatastoreField<?>>> it = d.getFields(); it.hasNext(); ) {
+                    Map.Entry<String, DatastoreField<?>> df = it.next();
+                    log.debug(df.getKey());
+                    sb.append(String.format("%s : %s\n", df.getKey(), df.getValue().typeString()));
+                    sb.append("\t");
+                    sb.append(cmd.datastore.getField(df.getKey(), guild).toString().replace("\n", "\\n"));
+                    sb.append("\n");
+                }
+
+                ctx.send(new GenericEmbedBuilder()
+                        .setTitle("Datastore Structure (`" + cmd.getClass().getCanonicalName() + "`)")
+                        .setDescription("```\n" + sb + "\n```")
+                        .build());
+
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                log.warn("Command doesn't have a datastore field. This normally shouldn't happen...");
+                ctx.sendError(new ExceptionEmbed()
+                        .setDescription("Could not find Datastore for Command\n" + e)
+                        .build());
+            }
+        } else {
+            ctx.send(new GenericEmbedBuilder()
+                    .setTitle("Datastore Structure")
+                    .setDescription("No command found.")
+                    .build());
+        }
+    }
+}

--- a/src/main/java/com/reign/kat/commands/debug/DebugParentCommand.java
+++ b/src/main/java/com/reign/kat/commands/debug/DebugParentCommand.java
@@ -19,6 +19,7 @@ public class DebugParentCommand extends Command
         registerSubcommand(new CommandExceptionTestCommand());
         registerSubcommand(new TestCommand());
         registerSubcommand(new VoiceStateCommand());
+        registerSubcommand(new DatastoreTestCommand());
     }
 
     @Override

--- a/src/main/java/com/reign/kat/commands/helpful/HelpfulCategory.java
+++ b/src/main/java/com/reign/kat/commands/helpful/HelpfulCategory.java
@@ -8,5 +8,8 @@ public class HelpfulCategory extends Category {
         setHelpMenuEmoji(":information_source:");
         registerCommand(new HelpCommand());
         registerCommand(new ConfigParentCommand());
+
+        registerCommand(new TagCommand());
+        registerCommand(new TagUtilityCommand());
     }
 }

--- a/src/main/java/com/reign/kat/commands/helpful/TagCommand.java
+++ b/src/main/java/com/reign/kat/commands/helpful/TagCommand.java
@@ -1,0 +1,36 @@
+package com.reign.kat.commands.helpful;
+
+import com.reign.api.kat.models.ApiGuild;
+import com.reign.kat.lib.command.Command;
+import com.reign.kat.lib.command.CommandParameters;
+import com.reign.kat.lib.command.Context;
+import com.reign.kat.lib.command.data.DatastoreField;
+import com.reign.kat.lib.converters.GreedyStringConverter;
+import com.reign.kat.lib.converters.MemberConverter;
+import net.dv8tion.jda.api.entities.Member;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TagCommand extends Command {
+
+
+    public TagCommand() {
+        super(new String[]{"t"}, "t", "Show the tag in chat.");
+
+        addConverter(new GreedyStringConverter("tagName", "Name of the tag", null));
+
+        setDatastore()
+                .addField("tag.tags", new DatastoreField<>(new HashMap<String, String>()));
+    }
+
+    @Override
+    public void execute(Context ctx, CommandParameters params) throws Exception {
+        ApiGuild guild = ApiGuild.get(ctx.guild.getId());
+
+        Map<String, String> tags = datastore.getField("tag.tags", guild);
+
+        String tagText = tags.get(params.get("tagName").toString());
+        ctx.send(tagText);
+    }
+}

--- a/src/main/java/com/reign/kat/commands/helpful/TagUtilityCommand.java
+++ b/src/main/java/com/reign/kat/commands/helpful/TagUtilityCommand.java
@@ -1,0 +1,61 @@
+package com.reign.kat.commands.helpful;
+
+import com.reign.api.kat.models.ApiGuild;
+import com.reign.kat.lib.command.Command;
+import com.reign.kat.lib.command.CommandParameters;
+import com.reign.kat.lib.command.Context;
+import com.reign.kat.lib.command.data.DatastoreField;
+import com.reign.kat.lib.converters.GreedyStringConverter;
+import com.reign.kat.lib.converters.StringConverter;
+import com.reign.kat.lib.embeds.GenericEmbedBuilder;
+import com.reign.kat.lib.exceptions.MissingArgumentCommandException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TagUtilityCommand extends Command {
+
+
+    public TagUtilityCommand() {
+        super(new String[]{"tag"}, "tag", "Add/Remove tags");
+
+        addConverter(new StringConverter("operation", "add/remove", "add"));
+        addConverter(new StringConverter("tagName", "Name of the tag", ""));
+        addConverter(new GreedyStringConverter("text", "Tag text", ""));
+        setDatastore()
+                .addField("tag.tags", new DatastoreField<>(new HashMap<String, String>()));
+    }
+
+
+    @Override
+    public void execute(Context ctx, CommandParameters params) throws Exception {
+        ApiGuild guild = ApiGuild.get(ctx.guild.getId());
+
+        Map<String, String> tags = datastore.getField("tag.tags", guild);
+
+        if (((String) params.get("text")).isEmpty()) {
+            throw new MissingArgumentCommandException("No tag text provided.");
+        }
+
+        if (((String) params.get("tagName")).isEmpty()) {
+            throw new MissingArgumentCommandException("No tag name provided.");
+        }
+
+
+        switch ((String) params.get("operation")) {
+            case "add" -> {
+                tags.put(params.get("tagName"), params.get("text"));
+                ctx.send("Added tag.");
+            }
+            case "remove" ->{
+                tags.remove((String) params.get("tagName"));
+                ctx.send("Removed tag.");
+
+            }
+            default ->
+                throw new MissingArgumentCommandException("Invalid operation (add/remove).");
+        }
+
+        datastore.updateField("tag.tags", tags, guild);
+    }
+}

--- a/src/main/java/com/reign/kat/lib/command/Command.java
+++ b/src/main/java/com/reign/kat/lib/command/Command.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.function.BiFunction;
 
 import com.reign.kat.lib.PermissionHandler;
+import com.reign.kat.lib.command.data.Datastore;
 import com.reign.kat.lib.converters.Converter;
 import com.reign.kat.lib.embeds.ExceptionEmbed;
 import com.reign.kat.lib.utils.PermissionGroupType;
@@ -46,6 +47,10 @@ public abstract class Command {
 
     /** List of argument Converters, parsed on command execution */
     public final ArrayList<Converter<?>> converters = new ArrayList<>();
+
+    /** Description of the data stored DB side */
+    public Datastore datastore;
+
 
     /** List of pre commands which are ran before command execution */
     public LinkedList<BiFunction<Context, CommandParameters, PreCommandResult>> precommands = new LinkedList<>();
@@ -117,7 +122,7 @@ public abstract class Command {
     public String getName(){return getPrimaryAlias();}
 
     public String getDescription() { return description; }
-
+    public List<Command> getChildren() { return children.values().stream().toList(); }
     public void setShowTyping(boolean status) {this.showTyping = status; }
     public boolean isShowTyping() { return showTyping; }
 
@@ -156,6 +161,16 @@ public abstract class Command {
             }
         }
         return sb.toString();
+    }
+
+    /**
+     * set the Datastore to be used for this command
+     * @return Datastore
+     */
+    public Datastore setDatastore()
+    {
+        datastore = new Datastore();
+        return datastore;
     }
 
     /**

--- a/src/main/java/com/reign/kat/lib/command/data/Datastore.java
+++ b/src/main/java/com/reign/kat/lib/command/data/Datastore.java
@@ -1,0 +1,31 @@
+package com.reign.kat.lib.command.data;
+
+import com.reign.api.kat.models.ApiGuild;
+import com.reign.api.lib.Pair;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+public class Datastore {
+    private final Map<String, DatastoreField<?>> fields = new HashMap<>();
+
+    public <T> Datastore addField(String fieldName, DatastoreField<T> type) {
+        fields.put(fieldName, type);
+        return this;
+    }
+
+    public Iterator<Map.Entry<String, DatastoreField<?>>> getFields() {
+        return fields.entrySet().iterator();
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T getField(String fieldName, ApiGuild guild) {
+        return (T) guild.commandData.getOrDefault(fieldName, null);
+    }
+
+    public <T> boolean updateField(String fieldName, T value, ApiGuild guild) {
+        guild.commandData.put(fieldName, value);
+        return guild.save();
+    }
+}

--- a/src/main/java/com/reign/kat/lib/command/data/DatastoreField.java
+++ b/src/main/java/com/reign/kat/lib/command/data/DatastoreField.java
@@ -1,0 +1,18 @@
+package com.reign.kat.lib.command.data;
+
+public class DatastoreField<T> {
+    T defaultValue;
+    T item;
+    Class<T> type;
+
+    @SuppressWarnings("unchecked")
+    public DatastoreField(T defaultValue)
+    {
+        this.defaultValue = defaultValue;
+        this.type = (Class<T>) defaultValue.getClass();
+    }
+
+    public String typeString() {
+        return type.toString();
+    }
+}


### PR DESCRIPTION
+ Adds datastore Api
+ Adds tag command (custom messaging commands per guild)
+ Adds tag utility command (adding and removing tags)

Commands can now describe the data they need stored in the DB.
```java
public TagCommand() {
        super(new String[]{"t"}, "t", "Show the tag in chat.");

        addConverter(new GreedyStringConverter("tagName", "Name of the tag", null));

        setDatastore()    // Indicates we will be storing/accessing data in the api.
                .addField("tag.tags", new DatastoreField<>(new HashMap<String, String>())); // Add a new field in the db.
    }
```

The data can then be accessed like so:
```java
public void execute(Context ctx, CommandParameters params) throws Exception {
        ApiGuild guild = ApiGuild.get(ctx.guild.getId());
        Map<String, String> tags = datastore.getField("tag.tags", guild); // Type here will be what ever declared in addField above
        /* ... */

and finally, if the data needs saving after editing:
```java
datastore.updateField("tag.tags", tags, guild);
```