### PR TITLE
fix 42: Check audioRecvManager != null before destroying

### DIFF
--- a/src/main/java/com/reign/kat/lib/voice/newvoice/GuildPlaylist.java
+++ b/src/main/java/com/reign/kat/lib/voice/newvoice/GuildPlaylist.java
@@ -185,7 +185,10 @@ public class GuildPlaylist extends AudioEventAdapter
         player.lavaPlayer.destroy();
 
         // Stop voice listeners
-        audioRecvManager.stopListening();
+        if (audioRecvManager != null)
+        {
+            audioRecvManager.stopListening();
+        }
 
     }
 


### PR DESCRIPTION
fixes #42 