### PR TITLE
51 yt sources new cipher server required

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.reign'
-version '1.3.6'
+version '1.3.8'
 
 repositories {
     mavenCentral()

--- a/config.properties.example
+++ b/config.properties.example
@@ -4,20 +4,26 @@ Customize these settings and rename the file to `config.properties`
 for your changes to take effect.
 
 ---
-
-bot-token=Your.Token.Here
+bot-token=your.token.here
 prefix=!
-tenor-api-key=APIKEYHERE
-backend-api-key=
-backend-api-host=
+tenor-api-key=TENORAPIKEY
+api-provider=mongodb
+backend-api-key=API_KEY_HERE
+backend-api-host=http://KAT_API_HOST_HERE
+
+mongodb-uri=mongodb://KAT_API_DB_HERE
+mongodb-name=KAT_DB_NAME
 
 voice-autodisconnect-minutes=5
-voice-spotify-client-id=
-voice-spotify-client-secret=
-voice-spotify-country-code=
+voice-spotify-client-id=SPOTIFY_CLIENT_ID
+voice-spotify-client-secret=SPOTIFY_CLIENT_SECRET
+voice-spotify-country-code=CC
 
 debug-mode=true
 debug-ignore-permission-sys=false
 
-speech-recognition-model-name=[folder name inside of voice-models/]
-speech-recognition-wake-words=a, list, of, comma, separated, english, words
+yt-po-token=YT_PO_TOKEN
+yt-visitor-data=YT_VISITOR_DATA_KEY
+
+yt-cipher-url=https://cipher.kikkia.dev/api
+yt-cipher-password=

--- a/src/main/java/com/reign/kat/lib/Config.java
+++ b/src/main/java/com/reign/kat/lib/Config.java
@@ -149,6 +149,8 @@ public class Config {
 
     public static String YT_PO_TOKEN = "";
     public static String YT_VISITOR_DATA = "";
+    public static String YT_CIPHER_URL = "";
+    public static String YT_CIPHER_PASSWORD = "";
 
     public static boolean load()
     {
@@ -194,6 +196,9 @@ public class Config {
 
                 YT_PO_TOKEN = config.getProperty("yt-po-token");
                 YT_VISITOR_DATA = config.getProperty("yt-visitor-data");
+
+                YT_CIPHER_URL = config.getProperty("yt-cipher-url");
+                YT_CIPHER_PASSWORD = config.getProperty("yt-cipher-password");
 
                 return true;
             } catch (Exception e)

--- a/src/main/java/com/reign/kat/lib/voice/newvoice/GuildPlaylistPool.java
+++ b/src/main/java/com/reign/kat/lib/voice/newvoice/GuildPlaylistPool.java
@@ -5,6 +5,7 @@ import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
+import dev.lavalink.youtube.YoutubeSourceOptions;
 import dev.lavalink.youtube.clients.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +39,10 @@ public class GuildPlaylistPool
         ClientOptions webOptions = new ClientOptions();
         webOptions.setPlayback(false);
 
-        YoutubeAudioSourceManager youtube = new YoutubeAudioSourceManager(true, new MWeb(), new Web(webOptions), new Music(), new TvHtml5Embedded(), new WebEmbedded(), new AndroidMusic());
+        YoutubeSourceOptions options = new YoutubeSourceOptions()
+                .setRemoteCipherUrl(Config.YT_CIPHER_URL, Config.YT_CIPHER_PASSWORD);
+
+        YoutubeAudioSourceManager youtube = new YoutubeAudioSourceManager(options, new MWeb(), new Web(webOptions), new Music(), new TvHtml5Embedded(), new WebEmbedded(), new AndroidMusic());
         //YoutubeAudioSourceManager youtube = new YoutubeAudioSourceManager(true, new Web());
         playerManager.registerSourceManager(youtube);
         AudioSourceManagers.registerRemoteSources(playerManager);


### PR DESCRIPTION
https://github.com/lavalink-devs/youtube-source?tab=readme-ov-file#using-a-remote-cipher-server

Default config example has also been updated with any missing properties since last checked.

`yt-cipher-url` defaults to `https://cipher.kikkia.dev/api`. https://github.com/kikkia/yt-cipher shows how to host your own instance of yt-cipher. This should hopefully reduce downtime of voice due to yt changing their algorithms.

fixes #51 